### PR TITLE
[FIX] cannot re-assign move when in inventory mode

### DIFF
--- a/stock_move_free_reservation_reassign/models/stock_quant.py
+++ b/stock_move_free_reservation_reassign/models/stock_quant.py
@@ -25,5 +25,7 @@ class StockQuant(models.Model):
         ]._get_move_free_reservation_ids() as move_to_reassign_ids:
             res = super()._apply_inventory()
         if move_to_reassign_ids:
-            self.env["stock.move"].browse(move_to_reassign_ids)._action_assign()
+            self.env["stock.move"].browse(move_to_reassign_ids).with_context(
+                inventory_mode=False
+            )._action_assign()
         return res


### PR DESCRIPTION
## Module
stock_move_free_reservation_reassign

## Describe the bug
After [this commit](https://github.com/odoo/odoo/commit/e21c17fae8a29c8ee04883b27d761b8ce13cf5b7) is merged, it cannot re-assign the stock move when applying the inventory in inventory mode.
Because re-assign the stock is going to update the field `reserved_quantity` which is not in allowed fields.

## To Reproduce
Run the tests and it will be failed
![image](https://github.com/nguyenminhchien/stock-logistics-workflow/assets/8724793/1edaa46d-a669-49e6-b239-577164d5eef3)

## Solution
Remove the context `inventory_mode=True` when re-assign stock move.